### PR TITLE
update PresentationService to return a hardcoded response for NoPrese…

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -31,3 +31,12 @@ export interface Presentation {
   presentationRequestUuid: string;
   proof: Proof
 }
+
+export interface NoPresentation {
+  type: ['NoPresentation' | 'Declination' | 'Report', ...string[]];
+  holder: string;
+  proof: Proof;
+  presentationRequestUuid: string;
+}
+
+export type PresentationOrNoPresentation = Presentation | NoPresentation;


### PR DESCRIPTION
…ntations

[Ticket](https://trello.com/c/zqA9t604/593-handle-nopresentations-part-1)

## Summary of Changes
- updates PresentationService to return a hardcoded response on receiving a NoPresentation
- logs the received NoPresentation

## Testing
- added a test case for NoPresentations
- tested locally with Postman