### PR TITLE
update auth header

### DIFF
--- a/src/channels.ts
+++ b/src/channels.ts
@@ -46,7 +46,7 @@ export default function (app: Application): void {
     // Here you can add event publishers to channels set up in `channels.js`
     // To publish only for a specific event use `app.publish(eventname, () => {})`
 
-    console.log('Publishing all events to all authenticated users. See `channels.js` and https://docs.feathersjs.com/api/channels.html for more information.'); // eslint-disable-line
+    // console.log('Publishing all events to all authenticated users. See `channels.js` and https://docs.feathersjs.com/api/channels.html for more information.'); // eslint-disable-line
 
     // e.g. to publish all service events to all authenticated users use
     return app.channel('authenticated');

--- a/src/services/IssuedCredentialService.ts
+++ b/src/services/IssuedCredentialService.ts
@@ -35,11 +35,7 @@ export async function issueCredential (ctx: HookContext): Promise<HookContext> {
 
   const url = `${config.ISSUER_URL}/api/issueCredentials`;
 
-  // this should use the Authorization header and a bearer token,
-  // but the issuer app expects this x-auth-token header instead
-  // TODO: update once the issuer app has been updated
-  const headers = { 'x-auth-token': issuer.authToken };
-  // const headers = { Authorization: `Bearer ${issuer.authToken}` };
+  const headers = { Authorization: `Bearer ${issuer.authToken}` };
 
   const response = await axios.post(url, options, { headers });
 

--- a/src/services/PresentationRequestService.ts
+++ b/src/services/PresentationRequestService.ts
@@ -41,7 +41,7 @@ export class PresentationRequestService {
     };
 
     const url = `${config.VERIFIER_URL}/api/sendRequest`;
-    const headers = { 'x-auth-token': verifier.authToken };
+    const headers = { Authorization: `Bearer ${verifier.authToken}` };
 
     const response = await axios.post(url, options, { headers });
 

--- a/src/services/PresentationService.ts
+++ b/src/services/PresentationService.ts
@@ -31,7 +31,7 @@ export class PresentationService {
 
     // verify presentation
     const url = `${config.VERIFIER_URL}/api/verifyPresentation`;
-    const headers = { 'x-auth-token': verifier.authToken };
+    const headers = { Authorization: `Bearer ${verifier.authToken}` };
 
     // for now, assume all NoPresentations are valid
     // TODO: remove or replace with actual implementation once Verifier-Server-App is updated

--- a/test/services/IssuedCredentialService.test.ts
+++ b/test/services/IssuedCredentialService.test.ts
@@ -126,9 +126,7 @@ describe('IssuedCredential service', () => {
       it('sends the issuer auth token to the issuer app', async () => {
         await issueCredential(ctx);
 
-        // TODO: update once issuer app has been updated to expect the correct header
-        const expected = { headers: { 'x-auth-token': dummyIssuer.authToken } };
-        // const expected = { headers: { Authorization: `Bearer ${dummyIssuer.authToken}` } };
+        const expected = { headers: { Authorization: `Bearer ${dummyIssuer.authToken}` } };
 
         expect((axios.post as jest.Mock).mock.calls[0][2]).toEqual(expected);
       });

--- a/test/services/PresentationService.test.ts
+++ b/test/services/PresentationService.test.ts
@@ -174,7 +174,7 @@ describe('PresentationService', () => {
       it('sends the presentation to the verifier app for verification', async () => {
         await supertest(app).post('/presentation').query({ verifier: verifier.uuid }).send(presentation);
         const expectedUrl = `${config.VERIFIER_URL}/api/verifyPresentation`;
-        const expectedHeaders = { 'x-auth-token': verifier.authToken };
+        const expectedHeaders = { Authorization: `Bearer ${verifier.authToken}` };
         const expectedData = {
           ...presentation,
           verifiableCredential: [{


### PR DESCRIPTION
[Ticket](https://trello.com/c/B1LMT58s/611-update-auth-headers-sent-to-issuer-verifier-server-apps)

## Summary of Changes
- updates auth headers sent to Issuer and Verifier apps to use `Authorization`  header and Bearer token