### PR TITLE
expect verifier and issuer keys in same format

### DIFF
--- a/src/services/VerifierService.ts
+++ b/src/services/VerifierService.ts
@@ -33,7 +33,7 @@ export async function registerVerifier (ctx: HookContext): Promise<HookContext> 
     ...ctx,
     data: {
       name: response.data.name,
-      privateKey: response.data.keys.privateKey,
+      privateKey: response.data.keys.signing.privateKey,
       did: response.data.did,
       authToken: response.headers['x-auth-token'],
       companyUuid: data.companyUuid

--- a/test/services/PresentationRequestService.test.ts
+++ b/test/services/PresentationRequestService.test.ts
@@ -57,7 +57,9 @@ describe('PresentationRequest service', () => {
         customerUuid: companyOptions.unumIdCustomerUuid,
         name: 'ACME Inc. TEST Verifier',
         keys: {
-          privateKey: '-----BEGIN EC PRIVATE KEY-----MHcCAQEEIIFtwDWUzCbfeikEgD4m6G58hQo51d2Qz6bL11AHDMbDoAoGCCqGSM49AwEHoUQDQgAEwte3H5BXDcJy+4z4avMsNuqXFGYfL3ewcU0pe+UrYbhh6B7oCdvSPocO55BZO5pAOF/qxa/NhwixxqFf9eWVFg==-----END EC PRIVATE KEY-----'
+          signing: {
+            privateKey: '-----BEGIN EC PRIVATE KEY-----MHcCAQEEIIFtwDWUzCbfeikEgD4m6G58hQo51d2Qz6bL11AHDMbDoAoGCCqGSM49AwEHoUQDQgAEwte3H5BXDcJy+4z4avMsNuqXFGYfL3ewcU0pe+UrYbhh6B7oCdvSPocO55BZO5pAOF/qxa/NhwixxqFf9eWVFg==-----END EC PRIVATE KEY-----'
+          }
         }
       };
 
@@ -178,7 +180,7 @@ describe('PresentationRequest service', () => {
             required: true,
             issuers: [mockReturnedIssuer.did]
           }],
-          eccPrivateKey: mockReturnedVerifier.keys.privateKey,
+          eccPrivateKey: mockReturnedVerifier.keys.signing.privateKey,
           holderAppUuid: holderApp.uuid
         };
         expect((axios.post as jest.Mock).mock.calls[3][1]).toEqual(expected);

--- a/test/services/PresentationService.test.ts
+++ b/test/services/PresentationService.test.ts
@@ -69,7 +69,9 @@ describe('PresentationService', () => {
         name: 'ACME Inc. TEST Verifier',
         url: `${config.BASE_URL}/presentation`,
         keys: {
-          privateKey: '-----BEGIN EC PRIVATE KEY-----MHcCAQEEIIFtwDWUzCbfeikEgD4m6G58hQo51d2Qz6bL11AHDMbDoAoGCCqGSM49AwEHoUQDQgAEwte3H5BXDcJy+4z4avMsNuqXFGYfL3ewcU0pe+UrYbhh6B7oCdvSPocO55BZO5pAOF/qxa/NhwixxqFf9eWVFg==-----END EC PRIVATE KEY-----'
+          signing: {
+            privateKey: '-----BEGIN EC PRIVATE KEY-----MHcCAQEEIIFtwDWUzCbfeikEgD4m6G58hQo51d2Qz6bL11AHDMbDoAoGCCqGSM49AwEHoUQDQgAEwte3H5BXDcJy+4z4avMsNuqXFGYfL3ewcU0pe+UrYbhh6B7oCdvSPocO55BZO5pAOF/qxa/NhwixxqFf9eWVFg==-----END EC PRIVATE KEY-----'
+          }
         }
       };
 

--- a/test/services/SharedCredentialService.test.ts
+++ b/test/services/SharedCredentialService.test.ts
@@ -108,7 +108,9 @@ describe('SharedCredential service', () => {
         customerUuid: dummyCompany.unumIdCustomerUuid,
         name: 'ACME Inc. TEST Verifier',
         keys: {
-          privateKey: '-----BEGIN EC PRIVATE KEY-----MHcCAQEEIIFtwDWUzCbfeikEgD4m6G58hQo51d2Qz6bL11AHDMbDoAoGCCqGSM49AwEHoUQDQgAEwte3H5BXDcJy+4z4avMsNuqXFGYfL3ewcU0pe+UrYbhh6B7oCdvSPocO55BZO5pAOF/qxa/NhwixxqFf9eWVFg==-----END EC PRIVATE KEY-----'
+          signing: {
+            privateKey: '-----BEGIN EC PRIVATE KEY-----MHcCAQEEIIFtwDWUzCbfeikEgD4m6G58hQo51d2Qz6bL11AHDMbDoAoGCCqGSM49AwEHoUQDQgAEwte3H5BXDcJy+4z4avMsNuqXFGYfL3ewcU0pe+UrYbhh6B7oCdvSPocO55BZO5pAOF/qxa/NhwixxqFf9eWVFg==-----END EC PRIVATE KEY-----'
+          }
         }
       };
       const mockReturnedHeaders = {

--- a/test/services/VerifierService.test.ts
+++ b/test/services/VerifierService.test.ts
@@ -52,7 +52,9 @@ describe('Verifier service', () => {
       customerUuid: dummyCompany.unumIdCustomerUuid,
       name: 'ACME Inc. TEST Verifier',
       keys: {
-        privateKey: '-----BEGIN EC PRIVATE KEY-----MHcCAQEEIIFtwDWUzCbfeikEgD4m6G58hQo51d2Qz6bL11AHDMbDoAoGCCqGSM49AwEHoUQDQgAEwte3H5BXDcJy+4z4avMsNuqXFGYfL3ewcU0pe+UrYbhh6B7oCdvSPocO55BZO5pAOF/qxa/NhwixxqFf9eWVFg==-----END EC PRIVATE KEY-----'
+        signing: {
+          privateKey: '-----BEGIN EC PRIVATE KEY-----MHcCAQEEIIFtwDWUzCbfeikEgD4m6G58hQo51d2Qz6bL11AHDMbDoAoGCCqGSM49AwEHoUQDQgAEwte3H5BXDcJy+4z4avMsNuqXFGYfL3ewcU0pe+UrYbhh6B7oCdvSPocO55BZO5pAOF/qxa/NhwixxqFf9eWVFg==-----END EC PRIVATE KEY-----'
+        }
       }
     };
     const mockReturnedHeaders = {
@@ -69,7 +71,7 @@ describe('Verifier service', () => {
       it('returns a new context with values from the verifier app', async () => {
         const newCtx = await registerVerifier(ctx);
         const newData = newCtx.data;
-        expect(newData.privateKey).toEqual(mockReturnedVerifier.keys.privateKey);
+        expect(newData.privateKey).toEqual(mockReturnedVerifier.keys.signing.privateKey);
         expect(newData.did).toEqual(mockReturnedVerifier.did);
         expect(newData.authToken).toEqual(mockReturnedHeaders['x-auth-token']);
         expect(newData.companyUuid).toEqual(dummyCompany.uuid);


### PR DESCRIPTION
[Ticket](https://trello.com/c/sjhqyrm0/627-make-issuer-and-verifier-key-object-format-consistent)

## Summary of Changes
- updates VerifierService to expect verifier keys to be nested inside a `signing` object (same as issuer)